### PR TITLE
Port to vim in libvte (terminal) instead of embedding gvim.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,5 +58,7 @@ if they need to be set to non-default values.
 
   + Python 3
   + Gtk 3, pygi
+  + Vte 2.91
+  + dbus-python
 
 .. vim: ft=rst tw=76 sts=4

--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
     "colors": {
         "foreground": "",
-        "background": ""
+        "background": "",
+        "palette": []
     },
     "font": "",
     "vim": "vim"

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+    "colors": {
+        "foreground": "",
+        "background": ""
+    },
+    "font": "",
+    "vim": "vim"
+}

--- a/io.github.kupferlauncher.kzrnote.service.in
+++ b/io.github.kupferlauncher.kzrnote.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=io.github.kupferlauncher.kzrnote
-Exec=@BINDIR@/kzrnote
+Exec=@BINDIR@/kzrnote --no-show

--- a/kzrnote.py
+++ b/kzrnote.py
@@ -2,7 +2,7 @@
 # vim: sts=4 sw=4 et ft=python foldmethod=marker
 
 APPNAME = "kzrnote"
-VIM = 'vim'
+VIM_DEFAULT = 'vim'
 ICONNAME = 'kzrnote'
 VERSION='0.2'
 
@@ -434,6 +434,13 @@ class Config:
         except OSError as exc:
             error("When reading config:", exc)
             return
+
+    def get_vim(self):
+        vim = self.config.get("vim")
+        if isinstance(vim, str) and vim:
+            return vim
+        else:
+            return VIM_DEFAULT
 
     def get_color(self, name):
         fg = self.config.get("colors", {}).get(name)
@@ -1169,7 +1176,7 @@ class MainInstance (ExportedGObject):
         window = Gtk.Window()
         window.set_default_size(*guess_default_window_size())
 
-        argv = [VIM]
+        argv = [self.config.get_vim()]
         argv.extend(VIM_EXTRA_FLAGS)
         argv.extend(['-S', self.write_vimrc_file()])
         argv.extend(extra_args)

--- a/kzrnote.py
+++ b/kzrnote.py
@@ -1161,10 +1161,14 @@ class MainInstance (ExportedGObject):
             else:
                 self.window.present()
         try:
-            for noteuri in arguments:
-                self.DisplayNote(noteuri)
+            for arg in arguments:
+                if arg == "--no-show":
+                    continue
+                elif arg.startswith("--"):
+                    error("Unknown argument", arg)
+                self.DisplayNote(arg)
         except ValueError as exc:
-            return "Argument %s: %s" % (noteuri, exc)
+            return "Argument %s: %s" % (arg, exc)
         return ""
 
     def handle_commandline_main(self, arguments, display, desktop_startup_id):

--- a/kzrnote.py
+++ b/kzrnote.py
@@ -1142,9 +1142,8 @@ class MainInstance (ExportedGObject):
         server_id = self.generate_vim_server_id()
 
         argv = [VIM]
-        argv.extend(['--servername', server_id])
         argv.extend(VIM_EXTRA_FLAGS)
-        argv.extend(['-c', 'so %s' % self.write_vimrc_file()])
+        argv.extend(['-S', self.write_vimrc_file()])
         argv.extend(extra_args)
 
 

--- a/kzrnote.py
+++ b/kzrnote.py
@@ -1240,7 +1240,7 @@ class MainInstance (ExportedGObject):
         terminal.connect("key-press-event", self.on_terminal_key_press_event)
 
         window.add(terminal)
-        window.show_all()
+        terminal.show()
         return window
 
     def on_spawn_child_setup(self):

--- a/kzrnote.py
+++ b/kzrnote.py
@@ -1361,6 +1361,9 @@ def main(argv):
         uargv.pop(0)
         global debug
         debug = True
+    elif uargv and uargv[0] == '--version':
+        print(VERSION)
+        sys.exit(0)
     else:
         debug = False
     desktop_startup_id = os.getenv("DESKTOP_STARTUP_ID", "")

--- a/kzrnote.py
+++ b/kzrnote.py
@@ -125,11 +125,15 @@ Example::
     {
         "colors": {
             "foreground": "black",
-            "background": "white"
+            "background": "white",
+            "palette": []
         },
         "font": "DejaVu Sans Mono 10",
         "vim": "vim"
     }
+
+Where palette is a list of 8, 16, 232 or 256 colors.
+(Can also be one string with ; separator).
 
 You can set kzrnote-specific vim settings in the
 file ~/.config/kzrnote/user.vim

--- a/kzrnote.py
+++ b/kzrnote.py
@@ -116,7 +116,21 @@ DATA_ABOUT_NOTE="""\
 Configuring kzrnote
 ...................
 
-You can set kzrnote-specific settings in the
+You can edit terminal colors, font and vim executable
+in ~/.config/kzrnote/config.json
+
+Example::
+
+    {
+        "colors": {
+            "foreground": "black",
+            "background": "white"
+        },
+        "font": "DejaVu Sans Mono 10",
+        "vim": "vim"
+    }
+
+You can set kzrnote-specific vim settings in the
 file ~/.config/kzrnote/user.vim
 
 You can set::

--- a/kzrnote.py
+++ b/kzrnote.py
@@ -26,7 +26,7 @@ from dbus.gi_service import ExportedGObject
 from dbus.mainloop.glib import DBusGMainLoop
 
 
-from gi.repository import GObject, GLib, Pango
+from gi.repository import GObject, GLib
 
 ## "Lazy imports"
 uuid = None
@@ -34,6 +34,7 @@ Gio = None
 Gdk = None
 Gtk = None
 Vte = None
+Pango = None
 
 debug = True
 
@@ -1323,10 +1324,8 @@ def main(argv):
         log("An instance already running, passing on commandline...")
         return service_send_commandline(uargv, "", desktop_startup_id)
     lazy_import("uuid")
-    lazy_import("Gtk", "gi.repository.Gtk")
-    lazy_import("Gdk", "gi.repository.Gdk")
-    lazy_import("Gio", "gi.repository.Gio")
-    lazy_import("Vte", "gi.repository.Vte")
+    for gi_mod in "Gtk Gdk Gio Vte Pango".split():
+        lazy_import(gi_mod, "gi.repository." + gi_mod)
     GLib.idle_add(m.setup_basic)
     GLib.idle_add(m.setup_gui)
     GLib.idle_add(m.handle_commandline_main, uargv, "", desktop_startup_id)

--- a/notemode.vim
+++ b/notemode.vim
@@ -163,7 +163,7 @@ let s:kzrnote_object = '/io/github/kupferlauncher/kzrnote'
 let s:kzrnote_interface = 'io.github.kupferlauncher.kzrnote'
 
 function! KzrnoteMethod (method, arg, sender)
-    silent exe '!dbus-send' '--type=method_call' '--print-reply'
+    silent exe '!dbus-send' '--type=method_call'
      \ '--dest=' . s:kzrnote_service s:kzrnote_object
      \ s:kzrnote_interface . '.' . a:method
      \ 'string:' . a:arg 'string:' . a:sender

--- a/notemode.vim
+++ b/notemode.vim
@@ -37,6 +37,9 @@ if $XDG_CONFIG_HOME == ''
     let $XDG_CONFIG_HOME = expand("~/.config")
 endif
 
+set viminfo+=n$XDG_CACHE_HOME/kzrnote/viminfo
+
+
 if !exists('s:cache_mtime')
     let s:have_cached_names = 0
     let s:have_cached_titles = 0

--- a/notemode.vim
+++ b/notemode.vim
@@ -37,7 +37,11 @@ if $XDG_CONFIG_HOME == ''
     let $XDG_CONFIG_HOME = expand("~/.config")
 endif
 
-set viminfo+=n$XDG_CACHE_HOME/kzrnote/viminfo
+if has('nvim')
+    set shada+=n$XDG_CACHE_HOME/kzrnote/nvimshada
+else
+    set viminfo+=n$XDG_CACHE_HOME/kzrnote/viminfo
+endif
 
 
 if !exists('s:cache_mtime')


### PR DESCRIPTION
- This is whether we like it or not, the future of vim embedding. GtkSocket still works in Gtk 3, but only on X11.
- Seems to work best with neovim.
- Changes dependencies. Now requires Vte, does not require gvim anymore, just regular vim or nvim
- New config file to set vim/nvim path and terminal colors